### PR TITLE
Corrects missing apostrophe on HM government

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -282,12 +282,12 @@ Max 14 characters for the most important password in your shared hosting environ
 
 |GoDaddy SFTP|
 
-`Her Majestys Revenue & Customs (UK Tax) <https://www.tax.service.gov.uk/government-gateway-registration-frontend?accountType=individual&continue=%2Fpersonal-account%2Fdo-uplift&origin=unknown>`__
+`Her Majesty’s Revenue & Customs (UK Tax) <https://www.tax.service.gov.uk/government-gateway-registration-frontend?accountType=individual&continue=%2Fpersonal-account%2Fdo-uplift&origin=unknown>`__
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 We store basically all of your data, but we can't store your password.
 
-|Her Majestys Revenue & Customs|
+|Her Majesty’s Revenue & Customs|
 
 
 
@@ -789,7 +789,7 @@ your password.
 .. |Global Entry| image:: /screenshots/global-entry.png
 .. |GoDaddy| image:: /screenshots/godaddy.png
 .. |GoDaddy SFTP| image:: /screenshots/godaddy-sftp.png
-.. |Her Majestys Revenue & Customs| image:: /screenshots/tax.service.gov.uk.png
+.. |Her Majesty’s Revenue & Customs| image:: /screenshots/tax.service.gov.uk.png
 .. |Intel| image:: /screenshots/intel.jpg
 .. |ING Bank| image:: /screenshots/ingbank.png
 .. |Izly by Crous| image:: /screenshots/izly-by-crous.png


### PR DESCRIPTION
Her Majesty has possession over Revenue and Customs.