### PR TITLE
Fix Nitpick

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -772,7 +772,7 @@ Passwords limited to 8-12 characters.
 `Singapore Airlines <https://www.singaporeair.com/en_UK/ppsclub-krisflyer/registration-form/>`__
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``/\d{6}/``
+``/[0-9]{6}/``
 
 |Singapore Airlines|
 


### PR DESCRIPTION
\d matches not just ASCII 0-9, but also localised numerals like ٠١٢٣٤٥٦٧٨٩.
I assume Singapore Airlines *doesn't* allow you to use those