### PR TITLE
Chase: Note that passwords are case-insensitive

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -277,6 +277,7 @@ Prevents spaces and a set list of characters, limits to 30 characters and can on
 * Can't use any special characters except ! # $ % + / = @ ~
 * Max length restriction (32 characters).
 * No runs of identical characters ("aaa") or sequential characters ("abc").
+* Password check is case-insensitive
 
 |Chase|
 


### PR DESCRIPTION
I (and a few others, see #192) confirmed that any other casing of the passwords allows to log in just the same, using the form at chase.com. I do not know if apps etc are case sensitive (if they are it is even scarier, since it would hint that they are storing the password in plain text).

Amends #192

See also #179, cc @rorymurphy