### PR TITLE
add additional dumb rule for Lenovo

### DIFF
--- a/src/_data/sites/lenovo.yml
+++ b/src/_data/sites/lenovo.yml
@@ -1,5 +1,8 @@
 description: |-
-  Between 8 and 20, not more.
+  - Between 8 and 20, not more.
+  - 1 alphabetic letter
+  - 1 number (0-9)
+  - 1 symbol ($!#&)
 images:
   - lenovo.png
 name: Lenovo

--- a/src/_data/sites/lenovo.yml
+++ b/src/_data/sites/lenovo.yml
@@ -1,8 +1,8 @@
 description: |-
-  - Between 8 and 20, not more.
+  - **Between 8 and 20 characters, not more.**
   - 1 alphabetic letter
   - 1 number (0-9)
-  - 1 symbol ($!#&)
+  - **1 symbol ($!#&)**
 images:
   - lenovo.png
 name: Lenovo


### PR DESCRIPTION
updates the rules, adds another that requires a set list of symbols, bolds the relevant rules
<img width="422" height="188" alt="image" src="https://github.com/user-attachments/assets/30f06237-71ac-44cb-ae3c-859140cf3699" />
